### PR TITLE
EPMRPP-50895. TestCaseId reporting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,27 @@ describe('suite',()=>{
 });
 ```
 
+#### Report test case id for steps and suites
+
+**setTestCaseId (*testCaseId*)**. Set test case id to the current test/suite. Should be called inside of corresponding test or suite.</br> 
+
+Mocha doesn't allow functional calls directly into describe section. You can call setTestCaseId inside of before/after hooks to set test case id to the corresponding suite. 
+
+**Example:**
+```javascript
+const PublicReportingAPI = require('agent-js-mocha/lib/publicReportingAPI');
+...
+describe('suite',()=>{
+  before(function (){
+    PublicReportingAPI.addAttributes([{ key: 'suiteAttr1Key', value: 'suiteAttr1Value' }, { value: 'suiteAttr2' }]);
+  });
+  it('test', () => {
+    PublicReportingAPI.addAttributes([{ key: 'testAttr1Key', value: 'testAttr1Value' }]);
+    PublicReportingAPI.addAttributes([{ value: 'testAttr2' }]);
+  });
+});
+```
+
 ## Run test example:
 For running test example clone [agent-js-mocha](https://github.com/reportportal/agent-js-mocha) and fill in [reporterOptions](#How-to-use).  
 

--- a/example/test.spec.js
+++ b/example/test.spec.js
@@ -34,6 +34,7 @@ describe('describe', function() {
   let foo = '';
   before(function() {
     PublicReportingAPI.setDescription('root describe');
+    PublicReportingAPI.setTestCaseId('describe_test_case_id');
     foo = 'bar';
   });
 
@@ -78,6 +79,7 @@ describe('describe', function() {
   it('test pass', function() {
     PublicReportingAPI.setDescription('passed test description');
     PublicReportingAPI.addAttributes([{ key: 'state', value: 'stable' }]);
+    PublicReportingAPI.setTestCaseId('test_pass_test_case_id');
     expect(true).to.be.equal(true);
   });
 

--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -31,6 +31,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
     this.suitesStackTempId = [];
     this.attributes = new Map();
     this.descriptions = new Map();
+    this.testCaseIds = new Map();
     this.options = options;
     this.registerRPListeners();
 
@@ -60,6 +61,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
     process.on(EVENTS.ADD_LAUNCH_LOG, this.sendLaunchLog.bind(this));
     process.on(EVENTS.ADD_ATTRIBUTES, this.onAddAttributes.bind(this));
     process.on(EVENTS.SET_DESCRIPTION, this.onSetDescription.bind(this));
+    process.on(EVENTS.SET_TEST_CASE_ID, this.onSetTestCaseId.bind(this));
   }
 
   getCurrentTestItemId() {
@@ -69,6 +71,11 @@ class ReportportalAgent extends Mocha.reporters.Base {
   onSetDescription({ text }) {
     const testItemId = this.getCurrentTestItemId();
     this.descriptions.set(testItemId, text);
+  }
+
+  onSetTestCaseId({ testCaseId }) {
+    const testItemId = this.getCurrentTestItemId();
+    this.testCaseIds.set(testItemId, testCaseId);
   }
 
   onAddAttributes({ attributes }) {
@@ -187,16 +194,19 @@ class ReportportalAgent extends Mocha.reporters.Base {
       if (suiteId) {
         const suiteAttributes = this.attributes.get(suiteId);
         const suiteDescription = this.descriptions.get(suiteId);
+        const suiteTestCaseId = this.testCaseIds.get(suiteId);
         const suiteFinishObj = Object.assign(
           {
             endTime: this.rpClient.helpers.now(),
           },
           suiteAttributes && { attributes: suiteAttributes },
           suiteDescription && { description: suiteDescription },
+          suiteTestCaseId && { testCaseId: suiteTestCaseId },
         );
         this.rpClient.finishTestItem(suiteId, suiteFinishObj);
         this.attributes.delete(suiteId);
         this.descriptions.delete(suiteId);
+        this.testCaseIds.delete(suiteId);
       }
       this.suitesStackTempId.pop();
     } catch (err) {
@@ -241,6 +251,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
       if (this.currentTest) {
         const testAttributes = this.attributes.get(this.currentTest.tempId);
         const testDescription = this.descriptions.get(this.currentTest.tempId);
+        const testCaseId = this.testCaseIds.get(this.currentTest.tempId);
         const withoutIssue =
           status === testStatuses.SKIPPED && this.options.reporterOptions.skippedIssue === false;
         const testFinishObj = Object.assign(
@@ -253,10 +264,12 @@ class ReportportalAgent extends Mocha.reporters.Base {
           withoutIssue && { issue: { issueType: 'NOT_ISSUE' } },
           testAttributes && { attributes: testAttributes },
           testDescription && { description: testDescription },
+          testCaseId && { testCaseId },
         );
         this.rpClient.finishTestItem(this.currentTest.tempId, testFinishObj);
         this.attributes.delete(this.currentTest.tempId);
         this.descriptions.delete(this.currentTest.tempId);
+        this.testCaseIds.delete(this.currentTest.tempId);
         this.currentTest = null;
       }
     } catch (err) {

--- a/lib/publicReportingAPI.js
+++ b/lib/publicReportingAPI.js
@@ -20,6 +20,7 @@ const PublicReportingAPI = {
   launchFatal: (message, file) => PublicReportingAPI.launchLog(LOG_LEVELS.FATAL, message, file),
   addAttributes: ClientPublicReportingAPI.addAttributes,
   setDescription: ClientPublicReportingAPI.setDescription,
+  setTestCaseId: ClientPublicReportingAPI.setTestCaseId,
 };
 
 module.exports = PublicReportingAPI;

--- a/test/testCaseIdReporting.test.js
+++ b/test/testCaseIdReporting.test.js
@@ -1,0 +1,59 @@
+const EventEmitter = require('events');
+const { getDefaultConfig, RPClient } = require('./mocks');
+const ReportportalAgent = require('./../lib/mochaReporter');
+
+describe('test case id reporting', function() {
+  let reporter;
+  beforeAll(function() {
+    const options = getDefaultConfig();
+    const runner = new EventEmitter();
+    reporter = new ReportportalAgent(runner, options);
+    reporter.rpClient = new RPClient(options);
+    reporter.suitesStackTempId = ['tempRootSuiteId', 'tempSuiteId'];
+  });
+
+  afterEach(function() {
+    reporter.currentTest = null;
+    reporter.testCaseIds.clear();
+    jest.clearAllMocks();
+  });
+
+  it('onSetTestCaseId: should set test case id for current test in the testCaseIds map', function() {
+    const currentTest = {
+      title: 'test',
+      tempId: 'testItemId',
+    };
+    reporter.currentTest = currentTest;
+    const testCaseId = 'test_case_id';
+    const expectedDescriptionsMap = new Map([['testItemId', testCaseId]]);
+
+    reporter.onSetTestCaseId({ testCaseId });
+
+    expect(reporter.testCaseIds).toEqual(expectedDescriptionsMap);
+  });
+
+  it('onSetTestCaseId: should overwrite test case id for current test in the testCaseIds map', function() {
+    const currentTest = {
+      title: 'test',
+      tempId: 'testItemId',
+    };
+    reporter.currentTest = currentTest;
+    reporter.testCaseIds.set('testItemId', 'old_test_case_id');
+    const newTestCaseId = 'new_test_case_id';
+
+    const expectedDescriptionsMap = new Map([['testItemId', newTestCaseId]]);
+
+    reporter.onSetTestCaseId({ testCaseId: newTestCaseId });
+
+    expect(reporter.testCaseIds).toEqual(expectedDescriptionsMap);
+  });
+
+  it('onSetTestCaseId: should set test case id for current suite in testCaseIds map', function() {
+    const testCaseId = 'suite_test_case_id';
+    const expectedDescriptionsMap = new Map([['tempSuiteId', testCaseId]]);
+
+    reporter.onSetTestCaseId({ testCaseId });
+
+    expect(reporter.testCaseIds).toEqual(expectedDescriptionsMap);
+  });
+});

--- a/test/testItemsReporting.test.js
+++ b/test/testItemsReporting.test.js
@@ -140,6 +140,26 @@ describe('test items reporting', function() {
 
       expect(spyFinishTestItem).toHaveBeenCalledWith('testItemId', expectedTestFinishObj);
     });
+    it('testCaseId exists for the test: should finish test with testCaseId', function() {
+      reporter = createAndPrepareReporter();
+      const spyFinishTestItem = jest.spyOn(reporter.rpClient, 'finishTestItem');
+      const currentTest = {
+        tempId: 'testItemId',
+      };
+      reporter.testCaseIds.set('testItemId', 'test_case_Id');
+
+      const expectedTestFinishObj = {
+        endTime: mockedDate,
+        retry: false,
+        status: 'passed',
+        testCaseId: 'test_case_Id',
+      };
+      reporter.currentTest = currentTest;
+
+      reporter.finishTest(currentTest, testStatuses.PASSED);
+
+      expect(spyFinishTestItem).toHaveBeenCalledWith('testItemId', expectedTestFinishObj);
+    });
   });
 
   describe('test event listeners', function() {


### PR DESCRIPTION
Works just with `"reportportal-client": "https://github.com/reportportal/client-javascript.git#EPMRPP-50892"`.
Doesn't work until backend not merged.