### PR TITLE
Cast skippedIssue to boolean

### DIFF
--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -151,8 +151,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
         system: true,
       },
     ];
-    if (this.options.reporterOptions.skippedIssue === false || 
-      this.options.reporterOptions.skippedIssue === 'false') {
+    if ([false,'false'].includes(this.options.reporterOptions.skippedIssue)) {
       this.options.reporterOptions.skippedIssue = false;
       const skippedIssueAttribute = {
         key: 'skippedIssue',

--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -151,10 +151,9 @@ class ReportportalAgent extends Mocha.reporters.Base {
         system: true,
       },
     ];
-    if (this.options.reporterOptions.skippedIssue.toLowerCase() === 'false') {
+    if (this.options.reporterOptions.skippedIssue === false || 
+      this.options.reporterOptions.skippedIssue === 'false') {
       this.options.reporterOptions.skippedIssue = false;
-    }
-    if (this.options.reporterOptions.skippedIssue === false) {
       const skippedIssueAttribute = {
         key: 'skippedIssue',
         value: 'false',

--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -151,7 +151,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
         system: true,
       },
     ];
-    if (this.options.reporterOptions.skippedIssue.toLowerCase() == 'false') {
+    if (this.options.reporterOptions.skippedIssue.toLowerCase() === 'false') {
       this.options.reporterOptions.skippedIssue = false
     }
     if (this.options.reporterOptions.skippedIssue === false) {

--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -152,7 +152,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
       },
     ];
     if (this.options.reporterOptions.skippedIssue.toLowerCase() === 'false') {
-      this.options.reporterOptions.skippedIssue = false
+      this.options.reporterOptions.skippedIssue = false;
     }
     if (this.options.reporterOptions.skippedIssue === false) {
       const skippedIssueAttribute = {

--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -151,6 +151,9 @@ class ReportportalAgent extends Mocha.reporters.Base {
         system: true,
       },
     ];
+    if (this.options.reporterOptions.skippedIssue.toLowerCase() == 'false') {
+      this.options.reporterOptions.skippedIssue = false
+    }
     if (this.options.reporterOptions.skippedIssue === false) {
       const skippedIssueAttribute = {
         key: 'skippedIssue',

--- a/lib/mochaReporter.js
+++ b/lib/mochaReporter.js
@@ -151,7 +151,7 @@ class ReportportalAgent extends Mocha.reporters.Base {
         system: true,
       },
     ];
-    if ([false,'false'].includes(this.options.reporterOptions.skippedIssue)) {
+    if ([false, 'false'].includes(this.options.reporterOptions.skippedIssue)) {
       this.options.reporterOptions.skippedIssue = false;
       const skippedIssueAttribute = {
         key: 'skippedIssue',


### PR DESCRIPTION
skippedIssue can be read in from config file as a string, needs casted for the deep equal
https://github.com/reportportal/agent-js-mocha/issues/46